### PR TITLE
Avoid nonfinal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,12 @@ target/
 
 # OS X
 .DS_Store
+
+# jenv
+
+
+# jenv
+.java-version
+
+# log files
+*.log


### PR DESCRIPTION
Avoid attempt to make java.awt.GraphicsEnvironment non final, as this breaks in Java 18+. (Attempting to the final modifier now throws an UnsupportedOperationException)

Instead, use ByteBuddy to return CTCGraphicsEnvironment when sun.awt.PlatformGraphicsInfo.createGE() is called.